### PR TITLE
Set copy reference of IL.dll to false.

### DIFF
--- a/EC.Core.Sideloader/EC.Core.Sideloader.csproj
+++ b/EC.Core.Sideloader/EC.Core.Sideloader.csproj
@@ -65,6 +65,7 @@
     </Reference>
     <Reference Include="IL">
       <HintPath>..\lib\IL.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
I'm pretty sure we don't need it to merge since it stays after compiling.